### PR TITLE
adding readonly for guardduty, inspector,iam analyzer

### DIFF
--- a/securityhub.tf
+++ b/securityhub.tf
@@ -30,5 +30,3 @@ resource "aws_iam_role_policy_attachment" "clq_securityhub_read_role_and_policy_
   policy_arn = aws_iam_policy.clq_securityhub_read_policy.arn
   role       = aws_iam_role.securityhub-read-role.id
 }
-
-// Test

--- a/securityhub.tf
+++ b/securityhub.tf
@@ -34,3 +34,5 @@ resource "aws_iam_role_policy_attachment" "clq_securityhub_read_role_and_policy_
   policy_arn = aws_iam_policy.clq_securityhub_read_policy.arn
   role       = aws_iam_role.securityhub-read-role.id
 }
+
+// Test

--- a/securityhub.tf
+++ b/securityhub.tf
@@ -17,11 +17,7 @@ data "aws_iam_policy_document" "clq_securityhub_read_policy_permissions" {
       "inspector:Get*",
       "inspector:List*",
       "inspector:Preview*",
-      "ec2:DescribeInstances",
-      "ec2:DescribeTags",
       "sns:ListTopics",
-      "events:DescribeRule",
-      "events:ListRuleNamesByTarget",
       "access-analyzer:Get*",
       "access-analyzer:List*"
     ]

--- a/securityhub.tf
+++ b/securityhub.tf
@@ -10,7 +10,20 @@ data "aws_iam_policy_document" "clq_securityhub_read_policy_permissions" {
     actions = [
       "securityhub:Get*",
       "securityhub:List*",
-      "securityhub:Describe*"
+      "securityhub:Describe*",
+      "guardduty:Get*",
+      "guardduty:List*",
+      "inspector:Describe*",
+      "inspector:Get*",
+      "inspector:List*",
+      "inspector:Preview*",
+      "ec2:DescribeInstances",
+      "ec2:DescribeTags",
+      "sns:ListTopics",
+      "events:DescribeRule",
+      "events:ListRuleNamesByTarget",
+      "access-analyzer:Get*",
+      "access-analyzer:List*"
     ]
     resources = [
       "*"]


### PR DESCRIPTION
Per Anil's request, I added readonly permissions for Guard Duty, Inspector, IAM analyzer - using respective AWS managed readonly policies as a reference. 